### PR TITLE
Update IO#write return type

### DIFF
--- a/src/openssl_ext/bio/mem_bio.cr
+++ b/src/openssl_ext/bio/mem_bio.cr
@@ -13,8 +13,9 @@ class OpenSSL::MemBIO < IO
     LibCrypto.bio_read(self, data, data.size)
   end
 
-  def write(data : Bytes) : Nil
+  def write(data : Bytes) : Int64
     LibCrypto.bio_write(self, data, data.size)
+    data.size.to_i64
   end
 
   def reset


### PR DESCRIPTION
This change is required to upgrade the shard to Crystal 0.35.0

If compatibility with older versions is wanted `{% if compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %}` can be used.

Related to changes in shards 0.11 I recommend adding a crystal property in the shard.yml to state which crystal version are expected to be used with this shard.

Feel free to close the PR and use it as input for a cleaner migration.