### PR TITLE
fix(mem bio): explicit return type warning

### DIFF
--- a/src/openssl_ext/bio/mem_bio.cr
+++ b/src/openssl_ext/bio/mem_bio.cr
@@ -13,9 +13,8 @@ class OpenSSL::MemBIO < IO
     LibCrypto.bio_read(self, data, data.size)
   end
 
-  def write(data : Bytes) : Int64
+  def write(data : Bytes) : Nil
     LibCrypto.bio_write(self, data, data.size)
-    data.size.to_i64
   end
 
   def reset


### PR DESCRIPTION
will not merge just yet as this breaks compatibility with crystal 0.35
will merge in a couple of crystal versions or when the warning becomes a compiler error